### PR TITLE
Fixing the bashrc loading in the buildenv

### DIFF
--- a/machineEnvironment.sh
+++ b/machineEnvironment.sh
@@ -115,7 +115,7 @@ elif [ "`hostname | grep bertie`" != "" ] ; then
     installdir="/home/spiros/Work/install"
     testdata="/home/spiros/Work/install/testdata"
 elif [ "`hostname | grep kesch`" != "" -o "`hostname | grep escha`" != "" ] ; then
-    . /etc/bashrc
+    . /etc/bashrc && true # In some conditions the omitted true triggered an error.
     . /usr/Modules/3.2.10/init/bash
     . /etc/profile.d/cray_pe.sh
     export host="kesch"


### PR DESCRIPTION
In some conditions (mainly when running jenkins) `. /etc/bashrc` can return an error.

Error condition: See line 119 on the right

![screen shot 2016-01-05 at 12 29 02](https://cloud.githubusercontent.com/assets/282446/12114315/1a356688-b3a9-11e5-9fe9-ff58ba455f5a.png)

Fixed:
![screen shot 2016-01-05 at 12 29 23](https://cloud.githubusercontent.com/assets/282446/12114318/1dbcce72-b3a9-11e5-975a-8a47deef5a68.png)
