### PR TITLE
More generic COSMO build

### DIFF
--- a/package_builder/build_cosmo.sh
+++ b/package_builder/build_cosmo.sh
@@ -1,11 +1,57 @@
 #!/usr/bin/env bash
 
+pWarning()
+{
+  msg=$1
+  YELLOW='\033[1;33m'
+  NC='\033[0m'
+  echo -e "${YELLOW}[WARNING]${NC} ${msg}"
+}
+
+pInfo()
+{
+  msg=$1
+  BLUE='\033[1;34m'
+  NC='\033[0m'
+  echo -e "${BLUE}[INFO]${NC} ${msg}"
+}
+
+pOk()
+{
+  msg=$1
+  GREEN='\033[1;32m'
+  NC='\033[0m'
+  echo -e "${GREEN}[OK]${NC} ${msg}"
+}
+
 exitError()
 {
+    RED='\033[0;31m'
+    NC='\033[0m'
+	echo -e "${RED}EXIT WITH ERROR${NC}"
 	echo "ERROR $1: $3" 1>&2
 	echo "ERROR     LOCATION=$0" 1>&2
 	echo "ERROR     LINE=$2" 1>&2
 	exit "$1"
+}
+
+countDown()
+{	
+	YELLOW='\033[1;33m'
+	NC='\033[0m'
+	secs=$1
+	msg=$2
+	while [ $secs -ge 0 ]; do
+   		echo -ne "${YELLOW}[WARNING]${NC} ${msg} $secs \033[0K\r"
+		sleep 1
+		: $((secs--))
+	done
+}
+
+clean5Down()
+{
+	countDown 5 "cleaning in"
+	pInfo "directory removed"
 }
 
 tryExit()
@@ -15,35 +61,51 @@ tryExit()
 	if [ "${status}" -ne 0 ]; then
 		echo "ERROR in ${action} with ${status}" >&2
 		exit "${status}"
-  fi
+	else
+		pOk "${action}"
+	fi
 }
 
 showUsage()
-{
-	echo "usage: $(basename "$0") -i install_prefix -t target -c compiler -s slave -b stella_branch -o stella_org -a cosmo_branch -q cosmo_org [-4] [-f kflat] [-l klevel] [-z] [-h]"
+{	
+	echo "Clone, compile and install COSMO-POMPA."
 	echo ""
-	echo "mandatory arguments:"
-	echo "-t        Target (e.g. cpu or gpu)"
-	echo "-s        Slave (the machine)"
-	echo "-f        STELLA K-Flat"
-	echo "-l        STELLA K-Level"
-	echo "-n        The name of the project"
-	echo "-b        The STELLA branch to checkout (e.g. crclim)"	
-	echo "-o        The STELLA github repository organisation (e.g. C2SM-RCM)"
-	echo "-a        The COSMO-POMPA branch to checkout (e.g. crclim)"	
-	echo "-q        The COSMO-POMPA github repository organisation (e.g. C2SM-RCM)"
+	echo "WARNING:"
+	echo " - the script clones the repositories in the working directory"
+	echo " - the script clones only what is built (see -g, -d or -p)"
+	echo " - the script deletes the stella and cosmo-pompa in the working directory before doing a clone (if needed)"
 	echo ""
-	echo "optional arguments:"
+	echo "USAGE:"
+	usage="$(basename "$0") -c compiler -t target -o stella_org -q cosmo_org"
+	usage="${usage} [-g] [-d] [-p] [-h] [-n name] [-s slave] [-b branch] [-f flat] [-l level] [-a branch] [-4] [-v] [-z] [-i prefix] [-x config]"
+
+	echo "${usage}"
+	echo ""
 	echo "-h        Show help"
-	echo "-4        Single precision (default: OFF)"
+	echo ""
+	echo "Mandatory arguments:"
 	echo "-c        Compiler (e.g. gnu, cray or pgi)"
-	echo "-v        Verbose mode"
-	echo "-z        Clean builds"
-	echo "-g        Do Stella GNU build"
-	echo "-d        Do CPP Dycore GNU build"
-	echo "-p        Do Cosmo-Pompa build"
-	echo "-i        Install prefix"
-	echo "-x        Do bit-reproducible build"
+	echo "-t        Target (e.g. cpu or gpu)"					
+	echo "-o        The STELLA github repository organization (e.g. MeteoSwiss-APN), if build requested (with -g)"	
+	echo "-q        The COSMO-POMPA github repository organization (e.g. C2SM-RCM), if build requested (with -d or -p)"
+	echo ""
+	echo "Optional arguments, see default:"	
+	echo "-n        The name of the project, default EMPTY"
+	echo "-s        Slave (the machine), default EMPTY"
+	echo "-b        The STELLA branch to checkout (e.g. crclim), default: master"
+	echo "-f        STELLA K-Flat, default 19"
+	echo "-l        STELLA K-Level, default 60"
+	echo "-a        The COSMO-POMPA branch to checkout (e.g. crclim), default: master"
+	echo "-4        Single precision, default: OFF"
+	echo "-v        Verbose mode, default: OFF"
+	echo "-z        Clean builds, default: OFF"
+	echo "-g        Do Stella GNU build, default: OFF"
+	echo "-d        Do CPP Dycore GNU build, default: OFF"
+	echo "-p        Do Cosmo-Pompa build, default: OFF"
+	echo "-i        Install prefix, default: current working directory"
+	echo "-x        Do bit-reproducible build and provide config file, default: OFF"
+	echo "-j        Use the default install path instead of the constructed installation path"
+	echo "-e        Debug build, default: OFF"
 }
 
 # set defaults and process command line options
@@ -57,19 +119,27 @@ parseOptions()
 	slave=""
 	kflat=""
 	klevel=""
-	stellaBranch=""
+	stellaBranch="master"
 	stellaOrg=""
-	cosmoBranch=""
+	cosmoBranch="master"
 	cosmoOrg=""
-	instPrefix=""
+	instPrefix=$(pwd)
 	verbosity=OFF
+	debugBuild=OFF
 	cleanup=OFF
+	# compile stella
 	doStella=OFF
+	# compile the dycore
 	doDycore=OFF
+	# compile cosmo
 	doPompa=OFF
+	# make reproducible executable
 	doRepro=OFF
+	configFile=""
+	# the CRCLIM branch
+	jenkinsPath=OFF
 
-	while getopts "h4n:c:b:o:a:q:t:s:f:l:vzgdpi:x" opt; do
+	while getopts "h4n:c:b:o:a:q:t:s:f:l:vzgdpi:x:je" opt; do
 		case "${opt}" in
 		h) 
 		    showUsage
@@ -128,7 +198,14 @@ parseOptions()
 		    ;;
 		x)
 		    doRepro=ON
+		    configFile=$OPTARG
 		    ;;
+		j)
+			jenkinsPath=ON
+			;;
+		e)
+			debugBuild=ON
+			;;			
 		\?) 
 		    showUsage
 		    exitError 601 ${LINENO} "invalid command line option (-${OPTARG})"
@@ -141,28 +218,20 @@ parseOptions()
 # make sure the working variable are set
 checkOptions()
 {	
-	test -n "${compiler}"     || exitError 603 ${LINENO} "Option <compiler> is not set"
-	test -n "${target}"       || exitError 604 ${LINENO} "Option <target> is not set"
-	test -n "${slave}"        || exitError 605 ${LINENO} "Option <slave> is not set"
-	test -n "${projName}"     || exitError 663 ${LINENO} "Option <projName> is not set"
+	echo "INFO: checking mandatory options"
+	test -n "${compiler}" || exitError 603 ${LINENO} "Option <compiler> is not set"
+	test -n "${target}" || exitError 604 ${LINENO} "Option <target> is not set"
 
 	if [ ${doStella} == "ON" ] ; then
-		test -n "${kflat}"        || exitError 606 ${LINENO} "Option <flat> is not set"
-		test -n "${klevel}"       || exitError 607 ${LINENO} "Option <klevel> is not set"
-		test -n "${stellaBranch}" || exitError 665 ${LINENO} "Option <stellaBranch> is not set"
-		test -n "${stellaOrg}"    || exitError 666 ${LINENO} "Option <stellaOrg> is not set"
+		test -n "${stellaOrg}" || exitError 666 ${LINENO} "Option <stellaOrg> is not set"
 	fi
 
 	if [ ${doDycore} == "ON" ] ; then
-		test -n "${kflat}"        || exitError 606 ${LINENO} "Option <flat> is not set"
-		test -n "${klevel}"       || exitError 607 ${LINENO} "Option <klevel> is not set"
-		test -n "${cosmoBranch}"  || exitError 667 ${LINENO} "Option <cosmoBranch> is not set"
-		test -n "${cosmoOrg}"     || exitError 668 ${LINENO} "Option <cosmoOrg> is not set"
+		test -n "${cosmoOrg}" || exitError 668 ${LINENO} "Option <cosmoOrg> is not set"
 	fi
 	
 	if [ ${doPompa} == "ON" ] ; then
-		test -n "${cosmoBranch}"  || exitError 667 ${LINENO} "Option <cosmoBranch> is not set"
-		test -n "${cosmoOrg}"     || exitError 668 ${LINENO} "Option <cosmoOrg> is not set"
+		test -n "${cosmoOrg}" || exitError 668 ${LINENO} "Option <cosmoOrg> is not set"
 	fi
 }
 
@@ -171,97 +240,211 @@ printConfig()
 	echo "==============================================================="
 	echo "BUILD CONFIGURATION"
 	echo "==============================================================="
-	echo "PROJECT NAME:             ${projName}"
-	echo "SINGLE PRECISION:         ${singleprec}"
-	echo "STELLA ORGANISATION:      ${stellaOrg}"
-	echo "STELLA BRANCH:            ${stellaBranch}"
-	echo "COSMO ORGANISATION:       ${cosmoOrg}"
-	echo "COSMO BRANCH:             ${cosmoBranch}"
-	echo "COMPILER:                 ${compiler}"
-	echo "TARGET:                   ${target}"
-	echo "SLAVE:                    ${slave}"
-	echo "K-FLAT:                   ${kflat}"
-	echo "K-LEVEL:                  ${klevel}"
-	echo "BIT-REPRO:                ${doRepro}"
-	echo "VERBOSE:                  ${verbosity}"
-	echo "CLEAN:                    ${cleanup}"
-	echo "DO STELLA COMPILATION:    ${doStella}"
-	echo "DO DYCORE COMPILATION:    ${doDycore}"
-	echo "DO POMPA COMPILATION:     ${doPompa}"
-	echo "INSTALL PREFIX:           ${instPrefix}"
+	echo "TASKS"
+	echo "  DO STELLA COMPILATION:    ${doStella}"
+	echo "  DO DYCORE COMPILATION:    ${doDycore}"
+	echo "  DO POMPA COMPILATION:     ${doPompa}"
+	echo "COMPILATION"
+	echo "  COMPILER:                 ${compiler}"
+	echo "  TARGET:                   ${target}"
+	echo "  SINGLE PRECISION:         ${singleprec}"
+	echo "  BIT-REPRODUCIBLE:         ${doRepro}"
+	if [ "${configFile}x" != "x" ]; then
+		echo "  CONFIG FILE (JSON):       ${configFile}"
+	else
+		echo "  CONFIG FILE (JSON):       N/A"
+	fi	
+	echo "  VERBOSE:                  ${verbosity}"
+	echo "  CLEAN:                    ${cleanup}"
+	echo "  DEBUG:                    ${debugBuild}"
+	echo "REPOSITORIES"
+	echo "  STELLA ORGANIZATION:      ${stellaOrg}"
+	echo "  STELLA BRANCH:            ${stellaBranch}"
+	if [ "${kflat}x" != "x" ]; then
+		echo "  K-FLAT:                   ${kflat}"
+	else
+		echo "  K-FLAT:                   DEFAULT"
+	fi
+	if [ "${klevel}x" != "x" ]; then
+		echo "  K-LEVEL:                  ${klevel}"
+	else
+		echo "  K-LEVEL:                  DEFAULT"
+	fi	
+	echo "  COSMO ORGANIZATION:       ${cosmoOrg}"
+	echo "  COSMO BRANCH:             ${cosmoBranch}"
+	echo "INSTALL PATHS"
+	if [ "${slave}x" != "x" ]; then	
+		echo "  SLAVE:                    ${slave}"
+	else
+		echo "  SLAVE:                    N/A"
+	fi
+	if [ "${projName}x" != "x" ]; then
+		echo "  PROJECT NAME:             ${projName}"
+	else
+		echo "  PROJECT NAME:             N/A"
+	fi
+	echo "  INSTALL PREFIX:           ${instPrefix}"
+	echo "  STELLA INSTALL:           ${stellapath}"
+	echo "  DYCORE INSTALL:           ${dycorepath}"
+	echo "  COSMO INSTALL:            ${cosmopath}"
 	echo "==============================================================="
 }
 
 # clone the repositories
 cloneTheRepos()
-{	
+{
+	cwd=$(pwd)
+	pInfo "cloning needed repositories"
 	# note that we clean the previous clone and they're supposed to be installed   
-	# on another directory (simpler solution)
+	# on another directory (simpler solution)	
 	if [ ${doStella} == "ON" ] ; then
-		echo "Clean previous stella directories"
-		\rm -rf stella
-		echo "Clone stella"
+		#echo "WARNING: Cleaning previous stella source directories in 5 [s]"
+		#echo "WARNING: ${cwd}/stella"
+		pWarning "cleaning previous stella source directories in 5 [s]"
+		pWarning "${cwd}/stella"
+		clean5Down
+		if [ -d stella ]; then
+			\rm -rf stella
+		fi
+		pInfo "cloning stella"
 		git clone git@github.com:"${stellaOrg}"/stella.git --branch "${stellaBranch}"
 	fi
 
 	if [ ${doDycore} == "ON" ] || [ ${doPompa} == "ON" ] ; then
-		echo "Clean previous cosmo-pompa directories"
-		\rm -rf cosmo-pompa
-		echo "Clone cosmo-pompa (with dycore)"
+		#echo "WARNING: cleaning previous cosmo-pompa source directories in 5 [s]"
+		#echo "WARNING: ${cwd}/cosmo-pompa"
+		pWarning "cleaning previous cosmo-pompa source directories in 5 [s]"
+		pWarning "${cwd}/cosmo-pompa"		
+		clean5Down
+		if [ -d cosmo-pompa ]; then
+			\rm -rf cosmo-pompa
+		fi
+		pInfo "cloning cosmo-pompa (with dycore)"
 		git clone git@github.com:"${cosmoOrg}"/cosmo-pompa.git --branch "${cosmoBranch}"
+		pInfo "updating submodules"
+		cd cosmo-pompa
+		git submodule update --init
+		cd ..
 	fi
 }
 
 setupBuilds()
 {
+	cwd=$1
+	
 	# single precision flag
 	moreFlag=""
 	if [ ${singleprec} == "ON" ] ; then
 		moreFlag="${moreFlag} -4"
 	fi
-
+	# verbosity flag
 	if [ ${verbosity} == "ON" ] ; then
 		moreFlag="${moreFlag} -v"
 	fi
-
+	# cleanup flag
 	if [ ${cleanup} == "ON" ] ; then
 		moreFlag="${moreFlag} -z"
 	fi
-
+	# debug flag
+	if [ ${debugBuild} == "ON" ] ; then
+		moreFlag="${moreFlag} -d"
+	fi
 	# compiler (for Stella and the Dycore)
 	gnuCompiler="gnu"
+
+	stellaDirName="stella"
+	if [ "${kflat}x" != "x" ]; then
+		stellaDirName="${stellaDirName}_kflat${kflat}"
+	fi
+
+	if [ "${klevel}x" != "x" ]; then
+		stellaDirName="${stellaDirName}_klevel${klevel}"
+	fi
+	
+	
+
+	if [[ "${instPrefix}" = /* ]] ; then
+	   pInfo "Absolute install prefix path"
+	else
+	   pInfo "Relative install prefix path. Appending current working directory"
+	   pInfo ${instPrefix}
+	   instPrefix="${cwd}/${instPrefix}"
+	   pInfo ${instPrefix}
+	fi
 	
 	# path and directory structures
-	stellapath="${instPrefix}/${slave}/crclim/stella_kflat${kflat}_klevel${klevel}/${projName}/${target}/${gnuCompiler}"
-	dycorepath="${instPrefix}/${slave}/crclim/dycore/${projName}/${target}/${gnuCompiler}"
-	cosmopath="${instPrefix}/${slave}/crclim/cosmo/${projName}/${target}/${compiler}"
+	installDir="${instPrefix}/${slave}/${projName}"
+	stellapath="${installDir}/${stellaDirName}/${target}/${gnuCompiler}"
+	dycorepath="${installDir}/dycore/${target}/${gnuCompiler}"
+	cosmopath="${installDir}/cosmo/${target}/${compiler}"
+}
 
+cleanPreviousInstall() 
+{
+	cwd=$(pwd)
 	# clean previous install path if needed
 	if [ ${doStella} == "ON" ] ; then
+		if [ -d "${stellapath}" ] ; then
+			pWarning "cleaning previous stella install directories in 5 [s] at:"
+			pWarning "${stellapath}"
+			clean5Down
 		\rm -rf "${stellapath:?}/"*
+		fi
+		pInfo "creating directory: ${stellapath}"
+		pInfo "at the current location: ${cwd}"
+		mkdir -p "${stellapath}"
 	fi
 	
 	if [ ${doDycore} == "ON" ] ; then
-		\rm -rf "${dycorepath:?}/"*
+		if [ -d "${dycorepath}" ] ; then
+			pWarning "cleaning previous dycore install directories in 5 [s] at:"
+			pWarning "${dycorepath}"
+			clean5Down
+			\rm -rf "${dycorepath:?}/"*
+		fi
+		pInfo "creating directory: ${dycorepath}"
+		pInfo "at the current location: ${cwd}"
+		mkdir -p "${dycorepath}"
 	fi
 	
 	if [ ${doPompa} == "ON" ] ; then
-		\rm -rf "${cosmopath:?}/"*
+		if [ -d "${cosmopath}" ] ; then
+			pWarning "cleaning previous cosmo install directories in 5 [s] at:"
+			pWarning "${cosmopath}"
+			clean5Down	
+			\rm -rf "${cosmopath:?}/"*
+		fi
+		pInfo "creating directory: ${cosmopath}"
+		pInfo "at the current location: ${cwd}"
+		mkdir -p "${cosmopath}"
 	fi
 }
 
 # compile and install stella
 doStellaCompilation()
 {
-	cd stella || exitError 608 ${LINENO} "Unable to change directory into stella"
-	if [ ${doRepro} == "ON" ] ; then
-		test/jenkins/build.sh "${moreFlag}" -c "${gnuCompiler}" -i "${stellapath}" -f "${kflat}" -k "${klevel}" -x
-		retCode=$?
+	kFlatLevels=""
+	if [ "${kflat}x" != "x" ]; then
+		kFlatLevels="${kFlatLevels} -f ${kflat}"		
 	else
-		test/jenkins/build.sh "${moreFlag}" -c "${gnuCompiler}" -i "${stellapath}" -f "${kflat}" -k "${klevel}"
-		retCode=$?
+		pInfo "K-FLAT is unset using default"
+	fi
+
+	if [ "${klevel}x" != "x" ]; then
+		kFlatLevels="${kFlatLevels} -k ${klevel}"
+	else
+		pInfo "K-LEVELS is unset using default"
+	fi
+
+	cd stella || exitError 608 ${LINENO} "Unable to change directory into stella"
+	
+	extraFlags="-c ${gnuCompiler} -i ${stellapath} ${kFlatLevels}"
+	if [ ${doRepro} == "ON" ] ; then
+		extraFlags="${extraFlags} -x"
 	fi
 	
+	test/jenkins/build.sh "${moreFlag}" "${extraFlags}"
+	retCode=$?
 	tryExit $retCode "STELLA BUILD"
 	cd .. || exitError 609 ${LINENO} "Unable to go back"
 }
@@ -270,7 +453,12 @@ doStellaCompilation()
 doDycoreCompilation()
 {
 	cd cosmo-pompa/dycore || exitError 610 ${LINENO} "Unable to change directory into cosmo-pompa/dycore"
-	test/jenkins/build.sh "${moreFlag}" -c "${gnuCompiler}" -t "${target}" -s "${stellapath}" -i "${dycorepath}" -s "${stellapath}"
+
+	extraFlags="-c ${gnuCompiler} -t ${target} -i ${dycorepath}"
+	if [ ${jenkinsPath} == "OFF" ] ; then
+		extraFlags="${extraFlags} -s ${stellapath}"
+	fi
+	test/jenkins/build.sh "${moreFlag}" "${extraFlags}"
 	retCode=$?
 	tryExit $retCode "DYCORE BUILD"
 	cd ../.. || exitError 611 ${LINENO} "Unable to go back"
@@ -279,8 +467,15 @@ doDycoreCompilation()
 # compile and install cosmo-pompa
 doCosmoCompilation()
 {
-	cd cosmo-pompa/cosmo || exitError 612 ${LINENO} "Unable to change directory into cosmo-pompa/cosmo"
-	test/jenkins/build.sh "${moreFlag}" -c "${compiler}" -t "${target}" -i "${cosmopath}" -x "${dycorepath}"
+	cd cosmo-pompa/cosmo || exitError 612 ${LINENO} "Unable to change directory into cosmo-pompa/cosmo"	
+
+	extraFlags="-c ${compiler} -t ${target} -i ${cosmopath}"
+	if [ ${doRepro} == "ON" ] || [ ${jenkinsPath} == "OFF" ] ; then
+		export CRCLIMJSON=${configFile}
+		extraFlags="${extraFlags} -x ${dycorepath}"
+	fi	
+
+	test/jenkins/build.sh "${moreFlag}" "${extraFlags}"
 	retCode=$?
 	tryExit $retCode "COSMO BUILD"
 	cd ../.. || exitError 612 ${LINENO} "Unable to go back"
@@ -296,13 +491,17 @@ parseOptions "$@"
 # check the command line options
 checkOptions
 
+# setup
+rootWd=$(pwd)
+setupBuilds $rootWd
+
 printConfig
 
 # clone
 cloneTheRepos
 
-# setup
-setupBuilds
+# clean and create install structure
+cleanPreviousInstall
 
 # compile and install
 if [ ${doStella} == "ON" ] ; then


### PR DESCRIPTION
This script allow to build the whole chain: STELLA, Dycore and COSMO-POMPA. It's configurable (as requested by the reviewer) regarding:

- the STELLA, Dycore and COSMO (can be the same) repositories to clone (organization and branch),
- the STELLA option: kflat and klevels (useful for crCLIM),
- the installation directories which is build on a prefix, slave name (if any) and project name (if any) and also the compiler and the target,
- clean build, single or double precision, verbose build.
- add pretty prints (info, warning, error)
- more options/flags to have a fine control on Pompa compilation

This script is used by the build test jenkins crCLIM plans.

