### PR TITLE
Update PGI version to 17.5 on Daint

### DIFF
--- a/env.daint.sh
+++ b/env.daint.sh
@@ -238,7 +238,7 @@ setFortranEnvironment()
         ;;
     pgi )
         module unload pgi
-        module load pgi/16.9.0
+        module load pgi/17.5.0
         # Load gcc/5.3.0 to link with the C++ Dynamical Core
         module load gcc/5.3.0
         export CXX=$GCC_PATH/snos/bin/g++


### PR DESCRIPTION
@lxavier We would like to change the compiler version for PGI on Daint so that we are testing the same version that Matthieu and Edouard are using.