### PR TITLE
Hack extern Kesch

### DIFF
--- a/slurmTools.sh
+++ b/slurmTools.sh
@@ -88,7 +88,13 @@ function launch_job {
   local sacct_status=1
 
   while [ $sacct_wait -lt $sacct_maxwait ] ; do
-      sacct --jobs ${jobid} -p -n -b -D 2>/dev/null > ${sacct_log}
+      # HACK>: XL, 12.11.2018 On Kesch an "extern" process is marked CANCELLED
+      # although all jobs are ok. CSCS is aware but no fix yet
+      # The "extern" process is ignored until further notice
+      #sacct --jobs ${jobid} -p -n -b -D 2>/dev/null > ${sacct_log}
+      sacct --jobs ${jobid} -p -n -b -D 2>/dev/null |grep -v extern > ${sacct_log}
+      #<HACK
+
       # Check that sacct returns COMPLETED
       grep -v '|COMPLETED|0:0|' ${sacct_log} >/dev/null
       if [ $? -eq 0 ]; then


### PR DESCRIPTION
On Kesch an "extern" process is marked CANCELLED
although all jobs are ok. CSCS is aware but no fix yet
The "extern" process is ignored until further notice

This causes most COSMO testsuite job to fail since 8.11.2018. Ticket at cscs is #33169