### PR TITLE
remove an LD_PRELOAD

### DIFF
--- a/submit.kesch-test.slurm
+++ b/submit.kesch-test.slurm
@@ -23,8 +23,6 @@ export MALLOC_TRIM_THRESHOLD_=536870912
 export G2G=1
 export MV2_USE_GPUDIRECT=0 #with this perf are ok
 
-export LD_PRELOAD=/opt/mvapich2/gdr/no-mcast/2.2/cuda8.0/mpirun/gnu4.8.5/lib64/libmpi.so
-
 <CMD>
 
 ########################################################


### PR DESCRIPTION
Does anyone need this LD_PRELOAD ? It is hardcoded to a particular version, and I think is the source of the problem of the dycore unittests in the RH7.5