### PR TITLE
Use boost 1.49.0 on kesch

### DIFF
--- a/env.kesch.sh
+++ b/env.kesch.sh
@@ -58,7 +58,7 @@ setupDefaults()
     export Boost_NO_SYSTEM_PATHS=true
     export Boost_NO_BOOST_CMAKE=true
 
-    export BOOST_ROOT=/project/c14/install/kesch/boost/boost_1_67_0/
+    export BOOST_ROOT=/project/c14/install/kesch/boost/boost_1_49_0/
     export BOOST_PATH=${BOOST_ROOT}
     export BOOST_INCLUDE=${BOOST_ROOT}/include/
 


### PR DESCRIPTION
It seems like the stella debug plan doesn't compile with 1.67.0