### PR TITLE
FIX: use of an obsolete branch

### DIFF
--- a/package_builder/build_claw.sh
+++ b/package_builder/build_claw.sh
@@ -117,7 +117,7 @@ if [[ ! -f $claw_compiler_install/libexec/claw_f_lib.sh || $REBUILD == YES ]]; t
   echo "=============================="
   echo "Build claw-compiler"
   if [ ! -d ${package_basedir}/claw-compiler ] ; then
-    git clone "${resources_repo}" -b add_cmake_flags_option
+    git clone "${resources_repo}"
   fi
 
   cd ${package_basedir}/claw-compiler


### PR DESCRIPTION
Forgot to delete the checkout to my old branch while fixing the claw repository path, see PR #85.