### PR TITLE
Fix UCX env variables

### DIFF
--- a/env.arolla.sh
+++ b/env.arolla.sh
@@ -159,6 +159,14 @@ EOF
         # Gnu env
         module load PrgEnv-gnu/19.2
 EOF
+        # Export env variables for gpu nodes on tsa
+        if [ "${target}" == "gpu" ] ; then
+            cat >> $ENVIRONMENT_TEMPFILE <<-EOF
+        # UCX env variables
+        export UCX_MEMTYPE_CACHE=n
+        export UCX_TLS=rc_x,ud_x,mm,shm,cuda_copy,cuda_ipc,cma
+EOF
+        fi
      fi
 
 #issue with module purge

--- a/env.arolla.sh
+++ b/env.arolla.sh
@@ -338,6 +338,14 @@ EOF
             export MPI_ROOT=\${EBROOTOPENMPI}
             export GRIBAPI_COSMO_RESOURCES_VERSION=${GRIBAPI_COSMO_RESOURCES_VERSION}
 EOF
+        # Export env variables for gpu nodes on tsa
+        if [ "${target}" == "gpu" ] ; then
+            cat >> $ENVIRONMENT_TEMPFILE <<-EOF
+            # UCX env variables
+            export UCX_MEMTYPE_CACHE=n
+            export UCX_TLS=rc_x,ud_x,mm,shm,cuda_copy,cuda_ipc,cma
+EOF
+        fi
         export FC=mpif90
         ;;
     * )

--- a/env.kesch.sh
+++ b/env.kesch.sh
@@ -313,7 +313,7 @@ EOF
 
     if [[ -z "$CLAWFC" ]]; then
       # CLAW Compiler using the correct preprocessor
-      export CLAWFC="${installdir}/claw/v1.2.3/${compiler}/bin/clawfc"
+      export CLAWFC="${installdir}/claw/v2.0.1/${compiler}/bin/clawfc"
     fi
     export CLAWXMODSPOOL="${installdir}/../omni-xmod-pool"
 


### PR DESCRIPTION
Add the UCX env variables to env.arolla.sh for GPU nodes. This means we don't have to export them in the submit scripts.