### PR TITLE
Added grib definition default path

### DIFF
--- a/submit.daint.slurm
+++ b/submit.daint.slurm
@@ -17,6 +17,13 @@ export MPICH_RDMA_ENABLED_CUDA=1
 export MPICH_G2G_PIPELINE=256
 export CRAY_CUDA_PROXY=0
 
+# Default grib_api ressources
+if ([ -z $GRIB_DEFINITION_PATH ]) then
+    GRIBAPI_DIR=/project/c14/install/tsa/libgrib_api/${GRIBAPI_COSMO_RESOURCES_VERSION}/pgi
+    echo "GRIBAPI_DIR=$GRIBAPI_DIR"
+    source $GRIBAPI_DIR/configuration.sh
+fi
+
 <CMD>
 
 ########################################################

--- a/submit.tsa.slurm
+++ b/submit.tsa.slurm
@@ -22,6 +22,13 @@ export MALLOC_MMAP_MAX_=0
 export MALLOC_TRIM_THRESHOLD_=536870912
 unset G2G
 
+# Default grib_api ressources
+if ([ -z $GRIB_DEFINITION_PATH ]) then
+    GRIBAPI_DIR=/project/c14/install/tsa/libgrib_api/${GRIBAPI_COSMO_RESOURCES_VERSION}/pgi
+    echo "GRIBAPI_DIR=$GRIBAPI_DIR"
+    source $GRIBAPI_DIR/configuration.sh
+fi
+
 <CMD>
 
 ########################################################


### PR DESCRIPTION
This is required for the new test with dycore. Needs to be adapted when migrating to spack