### PR TITLE
hardcoded module versions for Daint after the update in March 2021

### DIFF
--- a/env.daint.sh
+++ b/env.daint.sh
@@ -113,8 +113,6 @@ setCppEnvironment()
     esac
     module swap PrgEnv-gnu      PrgEnv-gnu/6.0.8
     module swap gcc             gcc/8.3.0
-    module swap craype          craype/2.7.0
-    module swap cray-mpich      cray-mpich/7.7.15
     module swap cray-libsci     cray-libsci/20.06.1
     module swap cray-libsci_acc cray-libsci_acc/20.06.1
     module swap cudatoolkit     cudatoolkit/10.2.89_3.29-7.0.2.1_3.5__g67354b4

--- a/env.daint.sh
+++ b/env.daint.sh
@@ -115,11 +115,7 @@ setCppEnvironment()
     module swap gcc             gcc/8.3.0
     module swap craype          craype/2.7.0
     module swap cray-mpich      cray-mpich/7.7.15
-    module swap slurm           slurm/20.02.6-1
     module swap cray-libsci     cray-libsci/20.06.1
-    module swap pmi             pmi/5.0.16
-    module swap atp             atp/3.7.4
-    module swap perftools-base  perftools-base/20.08.0
     module swap cray-libsci_acc cray-libsci_acc/20.06.1
     module swap cudatoolkit     cudatoolkit/10.2.89_3.29-7.0.2.1_3.5__g67354b4
 

--- a/env.daint.sh
+++ b/env.daint.sh
@@ -111,6 +111,17 @@ setCppEnvironment()
         echo "ERROR: Unsupported compiler encountered in setCppEnvironment" 1>&2
         exit 1
     esac
+    module swap PrgEnv-gnu      PrgEnv-gnu/6.0.8
+    module swap gcc             gcc/8.3.0
+    module swap craype          craype/2.7.0
+    module swap cray-mpich      cray-mpich/7.7.15
+    module swap slurm           slurm/20.02.6-1
+    module swap cray-libsci     cray-libsci/20.06.1
+    module swap pmi             pmi/5.0.16
+    module swap atp             atp/3.7.4
+    module swap perftools-base  perftools-base/20.08.0
+    module swap cray-libsci_acc cray-libsci_acc/20.06.1
+    module swap cudatoolkit     cudatoolkit/10.2.89_3.29-7.0.2.1_3.5__g67354b4
 
     # standard modules (part 2)
 
@@ -239,7 +250,9 @@ setFortranEnvironment()
         export FC=ftn
         ;;
     *pgi )
-        module swap pgi/20.1.0
+        module swap PrgEnv-pgi PrgEnv-pgi/6.0.8
+        module swap pgi        pgi/20.1.0
+        module unload cray-libsci_acc/20.06.1
         export CUDA_HOME=${CUDATOOLKIT_HOME}
         # Load gcc/8.3.0 to link with the C++ Dynamical Core
         module load gcc/8.3.0


### PR DESCRIPTION
it might be that not all the specified module versions are required, but the way it is now works for compilation and running on GPU (*NOT* tested on CPU)